### PR TITLE
Added --ipv4 flag to reload requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+.DS_Store
+lib-cov
+*.seed
+*.log
+*.csv
+*.dat
+*.out
+*.pid
+*.gz
+
+node_modules
+npm-debug.log
+
+*.sublime-project
+*.sublime-workspace

--- a/index.mk
+++ b/index.mk
@@ -18,7 +18,7 @@ reload: tiny-lr.pid
 tiny-lr.pid: $(LIVERELOAD_SRC)
 	@echo "File(s) changed: $?"
 	@touch $@
-	curl http://localhost:35729/changed?files=$(shell node -pe '"$?".split(" ").join(",")')
+	curl --ipv4 http://localhost:35729/changed?files=$(shell node -pe '"$?".split(" ").join(",")')
 
 livereload-start:
 	@echo ... Starting server, running in background ...

--- a/index.mk
+++ b/index.mk
@@ -11,8 +11,7 @@
 LIVERELOAD_DIR ?= ./
 LIVERELOAD_SRC ?= $(shell find $(LIVERELOAD_DIR) -name '*.css' -o -name '*.js')
 DEBUG ?= tinylr:cli
-DIR ?= $(dir $(lastword $(MAKEFILE_LIST)))
-TINYLR := $(DIR)/node_modules/.bin/tiny-lr
+TINYLR := $(PWD)/node_modules/.bin/tiny-lr
 
 reload: tiny-lr.pid
 tiny-lr.pid: $(LIVERELOAD_SRC)
@@ -29,6 +28,6 @@ livereload-start:
 livereload: livereload-start
 
 livereload-stop:
-	curl http://localhost:35729/kill
+	curl --ipv4 http://localhost:35729/kill
 
 .PHONY: livereload livereload-start livereload-stop reload


### PR DESCRIPTION
I updated to OSX 10.10 last night and `curl` (7.38.0) is returning Error (7) Connection refused on all reload requests from `make-livereload`. I'm very much aware this is most likely a bug in `libcurl` and I've reported there.

At the very least, this is a temporary patch until the `libcurl` team can push a patch on their end.
