### PR TITLE
Fix livereload server startup bug

### DIFF
--- a/index.mk
+++ b/index.mk
@@ -12,7 +12,7 @@ LIVERELOAD_DIR ?= ./
 LIVERELOAD_SRC ?= $(shell find $(LIVERELOAD_DIR) -name '*.css' -o -name '*.js')
 DEBUG ?= tinylr:cli
 DIR ?= $(dir $(lastword $(MAKEFILE_LIST)))
-TINYLR := $(DIR)/node_modules/.bin/tiny-lr
+TINYLR := "$(PWD)"/node_modules/.bin/tiny-lr
 
 reload: tiny-lr.pid
 tiny-lr.pid: $(LIVERELOAD_SRC)


### PR DESCRIPTION
when I try to start the livereload server via `make livereload` I get the following error: "/bin/sh: 1: node_modules/make-livereload//node_modules/.bin/tiny-lr: not found"
The imported index.mk somehow can't reference the tiny-lr executable. I don't know if others have the same problem but the change I propose fixes the problem for me.
