### PR TITLE
Add command-line options to support TLS.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+tiny-lr.pid
+node_modules
+key.pem
+cert.pem

--- a/bin/tiny-lr
+++ b/bin/tiny-lr
@@ -14,6 +14,8 @@ opts
   .version(require('../package').version)
   .option('port', '-p', 'Port to listen on (default: 35729)', Number)
   .option('pid', 'Path to the generated PID file (default: ./tiny-lr.pid)', String)
+  .option('--cert <path>', 'Path to the TLS certificate file (default: ./cert.pem)', String)
+  .option('--key <path>', 'Path to the TLS key file (default: ./key.pem)', String)
   .parse(process.argv);
 
 opts.port = opts.port || 35729;
@@ -71,5 +73,23 @@ var startServer = function() {
   });
 };
 
-startServer();
-
+if (opts.key && opts.cert) {
+  fs.readFile(opts.key, function(err,key) {
+    if (err) {
+      debug('Couldn\'t read key file (%s).', opts.key);
+      debug(err);
+      process.exit(1)
+    }
+    opts.key = key;
+    fs.readFile(opts.cert, function(err,cert) {
+      if (err) {
+        debug('Couldn\'t read cert file (%s).', opts.cert);
+        process.exit(1)
+      }
+      opts.cert = cert;
+      startServer();
+    });
+  });
+} else {
+  startServer();
+}

--- a/bin/tiny-lr
+++ b/bin/tiny-lr
@@ -49,23 +49,27 @@ process.on('SIGINT', function() {
   return process.exit(0);
 });
 
+var startServer = function() {
+  var srv = new Server(opts);
 
-var srv = new Server(opts);
-
-srv.on('close', function() {
-  process.nextTick(function() {
-    process.exit();
+  srv.on('close', function() {
+    process.nextTick(function() {
+      process.exit();
+    });
   });
-});
 
-srv.listen(opts.port, function(err) {
-  fs.writeFile(opts.pid, process.pid, function(err) {
-    if(err) {
-      debug('... Cannot write pid file: %s', opts.pid);
-      process.exit(1)
-    }
+  srv.listen(opts.port, function(err) {
+    fs.writeFile(opts.pid, process.pid, function(err) {
+      if(err) {
+        debug('... Cannot write pid file: %s', opts.pid);
+        process.exit(1)
+      }
 
-    debug('... Listening on %s (pid: %s) ...', opts.port, process.pid);
-    debug('... pid file: %s', opts.pid);
+      debug('... Listening on %s (pid: %s) ...', opts.port, process.pid);
+      debug('... pid file: %s', opts.pid);
+    });
   });
-});
+};
+
+startServer();
+


### PR DESCRIPTION
I needed to use LiveReload with TLS, so I added options to pass a path to a certificate and key so `tiny-lr` will serve over HTTPS.

The diff is a bit messy; the two commits clarify things a bit. The first pulls the lines to start the server into a function `startServer`. That way, the second commit can call that add TLS support directly, calling the `startServer` function after it reads the certificate and key files.
