### PR TITLE
fix pid file cleanup in process exit

### DIFF
--- a/bin/tiny-lr
+++ b/bin/tiny-lr
@@ -35,12 +35,15 @@ if (module.parent) {
 process.title = 'tiny-lr';
 
 process.on('exit', function() {
-  debug('... Closing server ...');
-  fs.exists(opts.pid, function(exists) {
-    if (!exists) return;
-    debug('... Removing pid file (%s) ...', opts.pid);
+  debug('... Closing server and removing PID file ...');
+  // remove PID file and catch if unable to delete
+  // must use unlinkSync because process exit must be synchronous
+  try {
     fs.unlinkSync(opts.pid);
-  });
+  }
+  catch (e) {
+    debug('... Unable to remove PID file (%s) ...', e.message);
+  }
 });
 
 process.on('SIGTERM', function() {


### PR DESCRIPTION
First off, thanks for this tool! It's making my life very easy with a project I'm working on.

There is, however, a slight problem with the process exit handler: it doesn't delete the PID file (at least not on my system running OSX and iojs 2.0.0). As per the [docs on the process exit event](https://nodejs.org/api/process.html#process_event_exit), asynchronous operations will not complete in the process exit handler. Thus, the fs.exists callback is never called, and the file is never deleted.

Rather than use the [deprecated](https://nodejs.org/api/fs.html#fs_fs_existssync_path) fs.existsSync, I opted to call fs.unlinkSync directly. The try-catch is ugly but the only way to get errors from the synchronous fs methods. Philosophically I think it makes more sense to try to delete the file and make noise if it doesn't work (whatever the reason) rather than check for the file's existence and then delete it with positive confirmation. PID file deletion is the expected result, and errors could still happen even if the file exists, so the error message ends up being useful.

I was also able to get the deletion to work with the synchronous version of unlink:

``` javascript
process.on('exit', function() {
  debug('... Closing server and removing PID file ...');
  fs.unlink(opts.pid, function(err) {
    debug('... Unable to remove PID file (%s) ...', err.message);
  });
});
```

While this certainly looks nicer, in my testing the callback was never called, even if the file was not deleted. This makes sense given how the process exit event works and makes me prefer the version in the pull request.
